### PR TITLE
Fixed a potential mistake in the fee calculation with round up

### DIFF
--- a/patterns/flash-loans/FlashLoanPool.sol
+++ b/patterns/flash-loans/FlashLoanPool.sol
@@ -48,7 +48,7 @@ contract FlashLoanPool {
         uint256 balanceBefore = token.balanceOf(address(this));
         require(balanceBefore >= borrowAmount, 'too much');
         // Compute the fee, rounded up.
-        uint256 fee = FEE_BPS * (borrowAmount + 1e4-1) / 1e4;
+        uint256 fee = (FEE_BPS * borrowAmount + 1e4-1) / 1e4;
         // Transfer tokens to the borrower contract.
         token.transfer(address(borrower), borrowAmount);
         // Let the borrower do its thing.

--- a/patterns/flash-loans/README.md
+++ b/patterns/flash-loans/README.md
@@ -76,7 +76,7 @@ function flashLoan(
     uint256 balanceBefore = token.balanceOf(address(this));
     require(balanceBefore >= borrowAmount, 'too much');
     // Compute the fee, rounded up.
-    uint256 fee = FEE_BPS * (borrowAmount + 1e4-1) / 1e4;
+    uint256 fee = (FEE_BPS * borrowAmount + 1e4-1) / 1e4;
     // Transfer tokens to the borrower contract.
     token.transfer(address(borrower), borrowAmount);
     // Let the borrower do its thing.

--- a/test/FlashLoanPool.t.sol
+++ b/test/FlashLoanPool.t.sol
@@ -161,7 +161,7 @@ contract FlashLoanPoolTest is TestUtils, FlashLoanValidator {
     }
     
     function _getFee(uint256 amount) private view returns (uint256) {
-        return pool.FEE_BPS() * (amount + 1e4-1) / 1e4;
+        return (pool.FEE_BPS() * amount + 1e4-1) / 1e4;
     }
 
     function test_canWithdraw() external {


### PR DESCRIPTION
Hi bro @merklejerk , my understanding of the fee calculation is like:
in the most direct way(no round up) it should be `FEE_BPS * borrowAmount / 1e4` (for example, 1% fee will make it `100 * borrowAmount / 10000`);
then, to add the round up, you just add 9999 to the **entire numerator**, so it should be `(FEE_BPS * borrowAmount + 1e4-1) / 1e4`, right? I think the opening parenthesis was in the wrong place in your code. Plz deny my PR if I'm wrong. 

Super nice repo btw
Sean